### PR TITLE
FIX: fix divide by zero when alpha channel is 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 # env file
 .env
+
+# example folder
+example/

--- a/redscii.go
+++ b/redscii.go
@@ -111,19 +111,21 @@ func getRawPixelRGBA(c color.Color) (uint32, uint32, uint32, uint32) {
 	r, g, b, a := c.RGBA()
 	switch c.(type) {
 	case color.NRGBA:
-		// Transform these to non aphla-premultiplied values.
 		a = a >> 8
-		r *= 0xFF
-		r /= a
-		r = r >> 8
+		// if alpha channel is zero (100% transparent), we can't do much here, all RGB values will be zero.
+		if a > 0 {
+			r *= 0xFF
+			r /= a
+			r = r >> 8
 
-		g *= 0xFF
-		g /= a
-		g = g >> 8
+			g *= 0xFF
+			g /= a
+			g = g >> 8
 
-		b *= 0xFF
-		b /= a
-		b = b >> 8
+			b *= 0xFF
+			b /= a
+			b = b >> 8
+		}
 
 	case color.RGBA:
 		// Values are assumed to be already premultiplied, return as is.

--- a/redscii_test.go
+++ b/redscii_test.go
@@ -161,6 +161,16 @@ func TestGetRawPixelRGBA(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("zero_alpha_NRGBA_test", func(t *testing.T) {
+		c := color.NRGBA{R: 255, G: 255, B: 255, A: 0}
+
+		r, g, b, a := getRawPixelRGBA(c)
+
+		if uint8(r) != 0 || uint8(g) != 0 || uint8(b) != 0 || uint8(a) != 0 {
+			t.Errorf("Expected color {%d, %d, %d, %d}, got {%d, %d, %d, %d}.", 0, 0, 0, 0, r, g, b, a)
+		}
+	})
 }
 
 func generateCustomSizeImage(r image.Rectangle, c color.RGBA) image.Image {


### PR DESCRIPTION
Fix divide by zero error when processing images with alpha channel values set to 0.